### PR TITLE
Don't require javascript for the "Get Started" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 				</span>
 			</div>
 			
-			<div id="btnCallToAction" class="call-to-action"></div>
+                        <div id="btnCallToAction" class="call-to-action"><a href="#readme">&nbsp;</a></div>
 		</div>
 		
 		<div class="sub-content">
@@ -62,7 +62,7 @@
 		
 			<div id="pnlInstructions" class="instructions" style="margin-bottom: 30px;">
 			
-				<span class="steps">
+				<span class="steps" id="readme">
 					<span class="title">STEP 1:</span>
 					<span class="description">Install localtunnel using RubyGems. Check the full <a class="highlight" href="https://github.com/progrium/localtunnel#readme">README</a> if you don't have Ruby or RubyGems.</span>
 					<span class="code-sample">$ sudo gem install localtunnel</span>

--- a/script/index.js
+++ b/script/index.js
@@ -14,6 +14,7 @@ Page = new function(){
 		
 		this.Elements["btnCallToAction"].click( function(e){ 
 			caller.ScrollToElement( caller.Elements["pnlInstructions"] ); 
+                        e.preventDefault();
 		}); 
 		
 		var i; 

--- a/style/index.css
+++ b/style/index.css
@@ -73,7 +73,7 @@ body {
 					float:left; 
 				}
 				
-		.content .call-to-action { 
+		.content .call-to-action a {
 			position:relative; 
 			display:block; 
 			width:224px; 
@@ -81,7 +81,8 @@ body {
 			background-image:url("../images/button_getstarted.png"); 
 			cursor:pointer; 
 			clear:both; 
-		} 
+			text-decoration:none; 
+		}
 		
 .sub-content { 
 	position:relative; 


### PR DESCRIPTION
Seems pretty ridiculous that you have to scroll yourself down the page if you have javascript off. And you can just link to http://progrium.com/localtunnel#readme now.

Minor, but it annoys me when such a simple thing is overlooked :)
