### PR TITLE
Solves auth problems on some platforms

### DIFF
--- a/lib/localtunnel/tunnel.rb
+++ b/lib/localtunnel/tunnel.rb
@@ -43,7 +43,7 @@ class LocalTunnel::Tunnel
   def start_tunnel
     port = @port
     tunnel = @tunnel
-    gateway = Net::SSH::Gateway.new(@host, tunnel['user'])
+    gateway = Net::SSH::Gateway.new(@host, tunnel['user'], :auth_methods => %w{ publickey })
     gateway.open_remote(port.to_i, '127.0.0.1', tunnel['through_port'].to_i) do |rp,rh|
       puts "   " << tunnel['banner'] if tunnel.has_key? 'banner'
       if File.exists?(File.expand_path(SHELL_HOOK_FILE))


### PR DESCRIPTION
On some machines you need to explicitly declare the publickey auth type for the gateway. 
