### PR TITLE
Link to documentation about how to create public keys

### DIFF
--- a/lib/localtunnel/tunnel.rb
+++ b/lib/localtunnel/tunnel.rb
@@ -66,7 +66,7 @@ class LocalTunnel::Tunnel
     puts "   Failed to authenticate. If this is your first tunnel, you need to"
     puts "   upload a public key using the -k option. Try this:\n\n"
     puts "   localtunnel -k #{possible_key ? possible_key : '~/path/to/key.pub'} #{port}\n\n"
-    puts "   Don't have a key? Try http://bit.ly/createsshkey"
+    puts "   Don't have a key? Check out http://bit.ly/createsshkey"
     exit
   end
 end


### PR DESCRIPTION
If the user tries to run Localtunnel and has never used SSH keys, they may get stuck at the command line. I add a link to the Github instructions for creating an SSH key in the error message when a user has never uploaded a key to the Localtunnel server. Their documentation on creating keys is the best I've found so far.
