### PR TITLE
Need to peek more bytes for Host header

### DIFF
--- a/localtunnel/server/frontend.py
+++ b/localtunnel/server/frontend.py
@@ -13,8 +13,8 @@ from localtunnel.server import metrics
 def peek_http_host(socket):
     host = ''
     hostheader = re.compile('host: ([^\(\);:,<>]+)', re.I)
-    # Peek up to 512 bytes into data for the Host header
-    for n in [128, 256, 512]:
+    # Peek up to 2048 bytes into data for the Host header
+    for n in [128, 256, 512, 1024, 2048]:
         bytes = socket.recv(n, MSG_PEEK)
         if not bytes:
             break


### PR DESCRIPTION
only peeking 512 bytes for the Host header is not enough in some cases.
Specifically if you have an OAuth authorization header, it's very long and causes the Host header to be out of the 512 byte range.

This pull request ups the number of bytes peeked to 2048
