### PR TITLE
Refactor client to let you pass in args

### DIFF
--- a/localtunnel/client/__init__.py
+++ b/localtunnel/client/__init__.py
@@ -1,1 +1,2 @@
 from .client import run
+from .client import start_client


### PR DESCRIPTION
I wanted to start the client from another piece of code so I could wrap it and add my own arguments but I needed to bypass localtunnel's call to argparse.  Let me know if you think there's a better way to handle this.
