### PR TITLE
Fixed an ImportError exception when loading localtunneld

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
     url="http://github.com/progrium/localtunnel",
     packages=find_packages(),
-    install_requires=['eventlet', 'requests', 'argparse'],
+    install_requires=['eventlet', 'requests', 'argparse', 'yunomi'],
     data_files=[],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
ubuntu@server:~/talkain$ localtunneld
Traceback (most recent call last):
  File "/usr/local/bin/localtunneld", line 9, in <module>
    load_entry_point('localtunnel==0.6.1', 'console_scripts', 'localtunneld')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 337, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2279, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1989, in load
    entry = **import**(self.module_name, globals(),globals(), ['**name**'])
  File "/usr/local/lib/python2.7/dist-packages/localtunnel/server/cli.py", line 9, in <module>
    from localtunnel.server.tunnel import Tunnel
  File "/usr/local/lib/python2.7/dist-packages/localtunnel/server/tunnel.py", line 11, in <module>
    from localtunnel.server import metrics
  File "/usr/local/lib/python2.7/dist-packages/localtunnel/server/metrics.py", line 6, in <module>
    from yunomi import dump_metrics
ImportError: No module named yunomi

Signed-off-by: Tal Kain tal.kain@ravellosystems.com
